### PR TITLE
Update interface for rigs - in/out versus None/cache

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -609,7 +609,8 @@ The `starter.rig` contains the necessary implementation and interface for animat
 
 ![set][] **Sets**
 
-- `cache_SEL (geometry)`: Meshes suitable for pointcaching from animation
+- `in_SEL (geometry, optional)`: Geometry consumed by this rig
+- `out_SEL (geometry)`: Geometry produced by this rig
 - `controls_SEL (transforms)`: All animatable controls
 - `resources_SEL (any, optional)`: Nodes that reference an external file
 

--- a/pyblish_starter/plugins/validate_rig_members.py
+++ b/pyblish_starter/plugins/validate_rig_members.py
@@ -5,8 +5,9 @@ class ValidateStarterRigFormat(pyblish.api.InstancePlugin):
     """A rig must have a certain hierarchy and members
 
     - Must reside within `rig_GRP` transform
+    - out_SEL
     - controls_SEL
-    - cache_SEL
+    - in_SEL (optional)
     - resources_SEL (optional)
 
     """
@@ -20,7 +21,7 @@ class ValidateStarterRigFormat(pyblish.api.InstancePlugin):
         missing = list()
 
         for member in ("controls_SEL",
-                       "cache_SEL"):
+                       "out_SEL"):
             if member not in instance:
                 missing.append(member)
 


### PR DESCRIPTION
Now rigs require an `out_SEL` as opposed to a `cache_SEL` so as to enable it's optional counterpart, `in_SEL` from rigs that aren't necessarily standalone; such as simulation rigs.
