### PR TITLE
add documented methods 'register_family' and 'register_data' to publi…

### DIFF
--- a/pyblish_starter/api.py
+++ b/pyblish_starter/api.py
@@ -26,6 +26,8 @@ from .pipeline import (
     register_host,
     register_format,
     register_plugins,
+    register_family,
+    register_data,
 
     deregister_plugins,
 


### PR DESCRIPTION
Just adding a couple of methods from pipeline.py to the public api since they're referenced in the [creator](http://pyblish.com/pyblish-starter/#creator) section of the doc, e.g.

```
from pyblish_starter import api

api.register_family(
    name="my.family",
    help="My custom family"
)
```
On the other hand, they're not listed in the Starter [API section](http://pyblish.com/pyblish-starter/#starter-api) so maybe it's the doc that should be updated - not the code?

Thanks!